### PR TITLE
Ability to create arbitrary exception stack traces in WinForms example

### DIFF
--- a/Examples/NBug.Examples.WinForms/MainForm.Designer.cs
+++ b/Examples/NBug.Examples.WinForms/MainForm.Designer.cs
@@ -28,20 +28,32 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
+            System.Windows.Forms.Label label1;
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
 			this.crashButton = new System.Windows.Forms.Button();
 			this.crashTypeComboBox = new System.Windows.Forms.ComboBox();
 			this.closeButton = new System.Windows.Forms.Button();
+            this.StackTextBox = new System.Windows.Forms.TextBox();
+            label1 = new System.Windows.Forms.Label();
 			this.SuspendLayout();
 			// 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(12, 56);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(307, 13);
+            label1.TabIndex = 1;
+            label1.Text = "Stack (use numbers for functions, comma for nested exception):";
+            // 
 			// crashButton
 			// 
 			this.crashButton.Image = ((System.Drawing.Image)(resources.GetObject("crashButton.Image")));
 			this.crashButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			this.crashButton.Location = new System.Drawing.Point(52, 68);
+            this.crashButton.Location = new System.Drawing.Point(53, 98);
 			this.crashButton.Name = "crashButton";
 			this.crashButton.Size = new System.Drawing.Size(127, 23);
-			this.crashButton.TabIndex = 0;
+            this.crashButton.TabIndex = 3;
 			this.crashButton.Text = "Generate Exception";
 			this.crashButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
 			this.crashButton.UseVisualStyleBackColor = true;
@@ -59,25 +71,34 @@
 			this.crashTypeComboBox.Location = new System.Drawing.Point(12, 27);
 			this.crashTypeComboBox.Name = "crashTypeComboBox";
 			this.crashTypeComboBox.Size = new System.Drawing.Size(317, 21);
-			this.crashTypeComboBox.TabIndex = 1;
+            this.crashTypeComboBox.TabIndex = 0;
 			// 
 			// closeButton
 			// 
 			this.closeButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.closeButton.Location = new System.Drawing.Point(198, 68);
+            this.closeButton.Location = new System.Drawing.Point(199, 98);
 			this.closeButton.Name = "closeButton";
 			this.closeButton.Size = new System.Drawing.Size(75, 23);
-			this.closeButton.TabIndex = 2;
+            this.closeButton.TabIndex = 4;
 			this.closeButton.Text = "Close";
 			this.closeButton.UseVisualStyleBackColor = true;
 			this.closeButton.Click += new System.EventHandler(this.CloseButton_Click);
 			// 
+            // StackTextBox
+            // 
+            this.StackTextBox.Location = new System.Drawing.Point(12, 72);
+            this.StackTextBox.Name = "StackTextBox";
+            this.StackTextBox.Size = new System.Drawing.Size(317, 20);
+            this.StackTextBox.TabIndex = 2;
+            // 
 			// MainForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.closeButton;
-			this.ClientSize = new System.Drawing.Size(341, 115);
+            this.ClientSize = new System.Drawing.Size(341, 132);
+            this.Controls.Add(this.StackTextBox);
+            this.Controls.Add(label1);
 			this.Controls.Add(this.closeButton);
 			this.Controls.Add(this.crashTypeComboBox);
 			this.Controls.Add(this.crashButton);
@@ -87,6 +108,7 @@
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
 			this.Text = "NBug - Test Application";
 			this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -95,6 +117,7 @@
 		private System.Windows.Forms.Button crashButton;
 		private System.Windows.Forms.ComboBox crashTypeComboBox;
 		private System.Windows.Forms.Button closeButton;
+        private System.Windows.Forms.TextBox StackTextBox;
 	}
 }
 

--- a/Examples/NBug.Examples.WinForms/MainForm.cs
+++ b/Examples/NBug.Examples.WinForms/MainForm.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 namespace NBug.Examples.WinForms
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Windows.Forms;
@@ -40,22 +41,80 @@ namespace NBug.Examples.WinForms
             this.Close();
         }
 
+        private void RollStack(int index, string text, Exception e)
+        {
+            if (text.Length == 0)
+                throw e;
+            if (index == text.Length)
+                return;
+            char c = text[index];
+            if (c == ',')
+            {
+                try
+                {
+                    RollStack(0, text.Substring(index + 1), e);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception(text.Substring(0, index), ex);
+                }
+            }
+            switch (((int)c - '0') % 10)
+            {
+                case 0: Zero(index + 1, text, e); break;
+                case 1: One(index + 1, text, e); break;
+                case 2: Two(index + 1, text, e); break;
+                case 3: Three(index + 1, text, e); break;
+                case 4: Four(index + 1, text, e); break;
+                case 5: Five(index + 1, text, e); break;
+                case 6: Six(index + 1, text, e); break;
+                case 7: Seven(index + 1, text, e); break;
+                case 8: Eight(index + 1, text, e); break;
+                case 9: Nine(index + 1, text, e); break;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Zero(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void One(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Two(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Three(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Four(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Five(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Six(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Seven(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Eight(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Nine(int index, string text, Exception e) { RollStack(index, text, e); throw e; }
+
         private void CrashButton_Click(object sender, EventArgs e)
         {
+            var text = "Selected exception: '" + this.crashTypeComboBox.Text + "' was thrown.";
             switch (this.crashTypeComboBox.Text)
             {
                 case "UI Thread: System.Exception":
-                    throw new Exception("Selected exception: '" + this.crashTypeComboBox.Text + "' was thrown.");
+                    RollStack(0, StackTextBox.Text, new Exception(text));
+                    break;
                 case "UI Thread: System.ArgumentException":
-                    throw new ArgumentException(
-                        "Selected exception: '" + this.crashTypeComboBox.Text + "' was thrown.",
+                    RollStack(0, StackTextBox.Text, new ArgumentException(
+                        text,
                         "MyInvalidParameter",
-                        new Exception("Test inner exception for argument exception."));
+                        new Exception("Test inner exception for argument exception.")));
+                    break;
                 case "Background Thread (Task): System.Exception":
-                    Task.Factory.StartNew(() => { throw new Exception(); });
+                    Task.Factory.StartNew(() => { RollStack(0, StackTextBox.Text, new Exception(text)); });
 
                     // Below code makes sure that exception is thrown as only after finalization, the aggregateexception is thrown.
-                    // As a side affect, unlike the normal behavior, the applicaiton will note continue its execution but will shut
+                    // As a side affect, unlike the normal behavior, the application will not continue its execution but will shut
                     // down just like any main thread exceptions, even if there is no handle to UnobservedTaskException!
                     // So remove below 3 lines to observe the normal continuation behavior.
                     Thread.Sleep(200);

--- a/Examples/NBug.Examples.WinForms/MainForm.resx
+++ b/Examples/NBug.Examples.WinForms/MainForm.resx
@@ -136,6 +136,9 @@
         AAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="label1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAABMLAAATCwAAAAAAAAAA


### PR DESCRIPTION
"Stack (use numbers for functions, comma for nested exception):" text
box added where a user can enter some random data that creates unique
exception stack with specified nesting level.

This is useful to test ability of crash report receiver to group similar reports to one bug and to separate different reports from others.

In previous implementation there was only two different stacks - one in CrashButton_Click and another one crash in lambda in a new thread.

Also there was no real test for inner exceptions. In the only one that existed inner exception was not thrown, it just was created and attached to another one, that is not as real things happen.

There is a little excess of RollStack, but I don't know an easy way how to solve this with few lines of code. The only easy way is [MethodImpl(MethodImplOptions.AggressiveInlining)], but it is supported only in .NET4.5. Anyway for test purposes any different stack is enough.

Example of new stack for "0987,6543" input:

System.Exception: Selected exception: 'UI Thread: System.Exception' was thrown.
 at NBug.Examples.WinForms.MainForm.Three(Int32 index, String text, Exception e) in MainForm.cs:85
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:68
 at NBug.Examples.WinForms.MainForm.Four(Int32 index, String text, Exception e) in MainForm.cs:87
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:69
 at NBug.Examples.WinForms.MainForm.Five(Int32 index, String text, Exception e) in MainForm.cs:89
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:70
 at NBug.Examples.WinForms.MainForm.Six(Int32 index, String text, Exception e) in MainForm.cs:91
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:71
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:55

System.Exception: 0987
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:74
 at NBug.Examples.WinForms.MainForm.Seven(Int32 index, String text, Exception e) in MainForm.cs:93
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:72
 at NBug.Examples.WinForms.MainForm.Eight(Int32 index, String text, Exception e) in MainForm.cs:95
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:73
 at NBug.Examples.WinForms.MainForm.Nine(Int32 index, String text, Exception e) in MainForm.cs:97
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:74
 at NBug.Examples.WinForms.MainForm.Zero(Int32 index, String text, Exception e) in MainForm.cs:79
 at NBug.Examples.WinForms.MainForm.RollStack(Int32 index, String text, Exception e) in MainForm.cs:65
 at NBug.Examples.WinForms.MainForm.CrashButton_Click(Object sender, EventArgs e) in MainForm.cs:125
 at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
 at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
 at System.Windows.Forms.Control.WndProc(Message& m)
 at System.Windows.Forms.ButtonBase.WndProc(Message& m)
 at System.Windows.Forms.Button.WndProc(Message& m)
 at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
