### PR TITLE
Fix bug where an email destination that uses a custom port does not get loaded

### DIFF
--- a/NBug.Configurator/SubmitPanels/Web/Mail.cs
+++ b/NBug.Configurator/SubmitPanels/Web/Mail.cs
@@ -105,7 +105,7 @@ namespace NBug.Configurator.SubmitPanels.Web
 				this.useAttachmentCheckBox.Checked = mail.UseAttachment;
 				this.portNumericUpDown.Value = mail.Port;
 
-				if (this.portNumericUpDown.Value == 25 || this.portNumericUpDown.Value == 465 || mail.Port > 0)
+				if (this.portNumericUpDown.Value == 25 || this.portNumericUpDown.Value == 465 || mail.Port == 0)
 				{
 					this.defaultPortCheckBox.Checked = true;
 				}


### PR DESCRIPTION
The default port checkbox in the email panel should get checked  if the port is 0 not greater than 0.