### PR TITLE
Fix bug where destination isn't loaded in app.config

### DIFF
--- a/NBug/Settings.cs
+++ b/NBug/Settings.cs
@@ -779,7 +779,7 @@ namespace NBug
 				document.Root.Element("connectionStrings")
 				        .Add(
 					        new XElement(
-						        "add", new XAttribute("name", "NBug.Properties.Settings.Connection" + number), new XAttribute("connectionString", Encrypt(content))));
+						        "add", new XAttribute("name", "NBug.Properties.Settings.Destination" + number), new XAttribute("connectionString", Encrypt(content))));
 			}
 		}
 


### PR DESCRIPTION
Currently, connection strings for destinations are saved in "add" elements with names prefixed with "NBug.Properties.Settings.Connection". This does not match the settings configured in NBug.Properties.Settings, so if NBug attempts to load an "app.config", it will not load the destinations properly. This commit changes the Settings class so it saves destination connnection strings with the prefix "NBug.Properties.Settings.Destination", which does match.