### PR TITLE
MailSubmitpanel selecting default value + useSsl in the configurator form will use port 25

### DIFF
--- a/NBug.Configurator/SubmitPanels/Web/Mail.cs
+++ b/NBug.Configurator/SubmitPanels/Web/Mail.cs
@@ -68,12 +68,7 @@ namespace NBug.Configurator.SubmitPanels.Web
 
 					mail.Bcc = mail.Bcc.TrimEnd(new[] { ',' });
 				}
-
-				if (!this.defaultPortCheckBox.Checked)
-				{
-					mail.Port = (int)this.portNumericUpDown.Value;
-				}
-
+				
 				if (this.useAuthenticationCheckBox.Checked)
 				{
                     mail.UseAuthentication = true;
@@ -82,6 +77,7 @@ namespace NBug.Configurator.SubmitPanels.Web
 				}
 
 				mail.UseSsl = this.useSslCheckBox.Checked;
+				mail.Port = (int)this.portNumericUpDown.Value;
 				mail.UseAttachment = this.useAttachmentCheckBox.Checked;
 
 				return mail.ConnectionString;


### PR DESCRIPTION
Fix bug where the email port is not read when the default port and use ssl checkboxes are checked.

When ssl is checked the port will be 25 even thought in the UI the correct value was visible.

The solution is the always read from the portNumericUpDown. Since the portNumericUpDown control always contains a value.