### PR TITLE
Only look for loadable types when doing reflection

### DIFF
--- a/NBug/Settings.cs
+++ b/NBug/Settings.cs
@@ -46,6 +46,19 @@ namespace NBug
 		/// </summary>
 		internal static Delegate CustomUIHandle;
 
+		internal static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+		{
+			if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException e)
+			{
+				return e.Types.Where(t => t != null);
+			}
+		}
+
 		/// <summary>
 		/// Lookup for quickly finding the type to instantiate for a given connection string type.
 		///
@@ -59,7 +72,7 @@ namespace NBug
 					var type = typeof(IProtocolFactory);
 					return
 						AppDomain.CurrentDomain.GetAssemblies()
-						         .SelectMany(s => s.GetTypes())
+						         .SelectMany(s => GetLoadableTypes(s))
 						         .Where(type.IsAssignableFrom)
 						         .Where(t => t.IsClass)
 						         .Where(t => !t.IsAbstract)


### PR DESCRIPTION
This was causing some esoteric errors with our application that selectively loads/uses assemblies, etc. when running on Windows 7 vs. Windows 10, -- the cause being an ignored `ReflectionTypeLoadException`.

This change shouldn't impact the functionality at all, but prevents this nasty bug!